### PR TITLE
Refatorar validade

### DIFF
--- a/src/Lib.hs
+++ b/src/Lib.hs
@@ -72,7 +72,7 @@ create produtos = do
   quantidade <- getLine
   putStrLn "Digite o preco do produto: "
   preco <- getLine
-  putStrLn "Digite a validade do produto (em meses): "
+  putStrLn "Digite a validade do produto (no formato DD/MM/YYYY): "
   validade <- getLine
 
   current <- getCurrentTime

--- a/src/Lib.hs
+++ b/src/Lib.hs
@@ -36,7 +36,7 @@ menu = do
   putStrLn "mp      - Modifica o preço de um produto"
   putStrLn "d       - Remove um produto do inventário"
   putStrLn "v       - Verifica validade dos produtos"
-  putStrLn "ch      - Verifica validade de um Produto"
+  putStrLn "cv      - Verifica validade de um Produto"
   putStrLn "z       - Verifica itens zerados"
   putStrLn "q       - Sair"
   prompt produtos
@@ -113,8 +113,7 @@ checaValidade produtos = do
   putStrLn "Digite o uid do produto: "
   uid <- getLine
 
-  -- get a product by uid
-  let produto = head (filter (\p -> getUid p == read uid) produtos)
+  let produto = head (filter (\p -> getUid p == read uid) produtos) -- get a product by uid
 
   c <- getCurrentTime
   let invalid = verifyValidadeProduto produto $ utctDay c
@@ -170,7 +169,9 @@ filterByQuantityZero produtos = do
   print (verifyStorage produtos)
   prompt produtos
 
--- Filtra o estoque por produtos vencidos
+{-
+Filtra o estoque por produtos vencidos
+-}
 filterByValidade :: [Produto] -> IO ()
 filterByValidade produtos = do
   c <- getCurrentTime

--- a/src/Lib.hs
+++ b/src/Lib.hs
@@ -36,7 +36,7 @@ menu = do
   putStrLn "mp      - Modifica o preço de um produto"
   putStrLn "d       - Remove um produto do inventário"
   putStrLn "v       - Verifica validade dos produtos"
-  putStrLn "ch      - Verifica validade de um Produto" 
+  putStrLn "ch      - Verifica validade de um Produto"
   putStrLn "z       - Verifica itens zerados"
   putStrLn "q       - Sair"
   prompt produtos
@@ -77,8 +77,9 @@ create produtos = do
 
   current <- getCurrentTime
   let today = formatDate current
-  let parsedValidade = parseTimeM True defaultTimeLocale "%d/%m/%0Y" validade :: Maybe Day
-  if isJust parsedValidade then do
+  
+  let isDateValid = maybe False (verifyVencido (utctDay current)) (parseDate validade)
+  if isDateValid then do
     let product = createProduct uid name quantidade preco validade today today
     writeStorage (produtos ++ [product])
     prompt (produtos ++ [product])
@@ -114,8 +115,8 @@ checaValidade produtos = do
 
   -- get a product by uid
   let produto = head (filter (\p -> getUid p == read uid) produtos)
-  
-  c <- getCurrentTime 
+
+  c <- getCurrentTime
   let invalid = verifyValidadeProduto produto $ utctDay c
   if invalid then
     print "Fora da Validade"
@@ -172,11 +173,21 @@ filterByQuantityZero produtos = do
 -- Filtra o estoque por produtos vencidos
 filterByValidade :: [Produto] -> IO ()
 filterByValidade produtos = do
-  c <- getCurrentTime 
+  c <- getCurrentTime
   putStrLn ""
   putStrLn "uid | nome | quantidade | preco | validade | created_at | updated_at"
   mapM_ print $ verifyValidadeEstoque produtos (utctDay c)
   prompt produtos
 
+
+--Mover para Util
 formatDate :: UTCTime -> String
 formatDate = formatTime defaultTimeLocale "%d/%m/%0Y"
+
+--Mover para Util
+verifyVencido :: Day -> Day -> Bool 
+verifyVencido currentDate userDate = diffDays userDate currentDate >= 0
+
+--Mover para Util
+parseDate :: String -> Maybe Day
+parseDate = parseTimeM True defaultTimeLocale "%d/%m/%0Y"

--- a/src/Storage.hs
+++ b/src/Storage.hs
@@ -138,7 +138,7 @@ verifyStorage produtos =
 
 -- Verifica a validade de um Produto em certa data. Retorna True se o produto estiver vencido
 verifyValidadeProduto :: Produto -> Day -> Bool
-verifyValidadeProduto produto dia = validade produto /= "" && diffDays dataValidade dia < 0
+verifyValidadeProduto produto dia = diffDays dataValidade dia <= 0
   where
     dataValidade = fromJust $ parseTimeM True defaultTimeLocale "%d/%m/%0Y" (validade produto)
 

--- a/src/Storage.hs
+++ b/src/Storage.hs
@@ -7,7 +7,8 @@ module Storage
     writeStorage,
     createProduct,
     verifyStorage,
-    verifyValidade,
+    verifyValidadeEstoque,
+    verifyValidadeProduto,
     uid,
     nome,
     quantidade,
@@ -137,17 +138,17 @@ verifyStorage produtos =
 
 -- Verifica a validade de um Produto em certa data. Retorna True se o produto estiver vencido
 verifyValidadeProduto :: Produto -> Day -> Bool
-verifyValidadeProduto produto dia = read (validade produto) /= 0 && diffDays dataValidade dia < 0
+verifyValidadeProduto produto dia = validade produto /= "" && diffDays dataValidade dia < 0
   where
-    dataValidade = addGregorianMonthsRollOver (read $ validade produto) $ fromJust $ parseTimeM True defaultTimeLocale "%d/%m/%0Y" (created_at produto)
+    dataValidade = fromJust $ parseTimeM True defaultTimeLocale "%d/%m/%0Y" (validade produto)
 
 -- Verifica a validade dos produtos em certa data. Retorna uma lista de produtos vencidos.
-verifyValidade :: [Produto] -> Day -> [Produto]
-verifyValidade [] dia = []
-verifyValidade produtos dia =
+verifyValidadeEstoque :: [Produto] -> Day -> [Produto]
+verifyValidadeEstoque [] dia = []
+verifyValidadeEstoque produtos dia =
   if verifyValidadeProduto (head produtos) dia
-    then head produtos : verifyValidade (tail produtos) dia
-    else verifyValidade (tail produtos) dia
+    then head produtos : verifyValidadeEstoque (tail produtos) dia
+    else verifyValidadeEstoque (tail produtos) dia
 
 createProduct :: Int -> String -> String -> String -> String -> String -> String -> Produto
 createProduct = Produto

--- a/src/Storage.hs
+++ b/src/Storage.hs
@@ -128,7 +128,9 @@ updateUidAux produtos = do
 
   produto' : updateUidAux (tail produtos)
 
--- Verifica os produtos que se esgotaram do estoque
+{-
+Verifica os produtos que se esgotaram do estoque
+-}
 verifyStorage :: [Produto] -> [Produto]
 verifyStorage [] = []
 verifyStorage produtos =
@@ -136,13 +138,19 @@ verifyStorage produtos =
     then head produtos : verifyStorage (tail produtos)
     else verifyStorage (tail produtos)
 
--- Verifica a validade de um Produto em certa data. Retorna True se o produto estiver vencido
+{-
+Verifica a validade de um Produto em certa data. 
+Retorna True se o produto estiver vencido
+-}
 verifyValidadeProduto :: Produto -> Day -> Bool
 verifyValidadeProduto produto dia = diffDays dataValidade dia <= 0
   where
     dataValidade = fromJust $ parseTimeM True defaultTimeLocale "%d/%m/%0Y" (validade produto)
 
--- Verifica a validade dos produtos em certa data. Retorna uma lista de produtos vencidos.
+{- 
+Verifica a validade dos produtos em certa data. 
+Retorna uma lista de produtos vencidos.
+-}
 verifyValidadeEstoque :: [Produto] -> Day -> [Produto]
 verifyValidadeEstoque [] dia = []
 verifyValidadeEstoque produtos dia =


### PR DESCRIPTION
Refeitas operações de validade, utilizanda datas no formato DD/MM/YYYY. Não permite criação de produtos já vencidos ou com data inválida.